### PR TITLE
feat(build): drop Go 1.21 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     strategy:
       matrix:
-        go: [ '1.21', '1.22', '1.23' ]
+        go: [ '1.22', '1.23' ]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,63 @@
+run:
+  deadline: 5m
+  allow-parallel-runners: true
+  modules-download-mode: readonly
+
+linters-settings:
+  govet:
+    enable=fieldalignment: true
+  revive:
+    rules:
+      # The following rules are recommended https://github.com/mgechev/revive#recommended-configuration
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      #
+      # Rules in addition to the recommended configuration above.
+      #
+      - name: bool-literal-in-expr
+      - name: constant-logical-expr
+
+linters:
+  disable-all: true
+  enable:
+    - copyloopvar
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - prealloc
+    - revive
+    - staticcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ OUTDIR ?= $(TMPDIR)
 
 # Dynamic version selection based on Go version
 # Format: $(TOOLSDIR)/get_version.sh <go_version> <tool_version1> <tool_version2> ..
-GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.59 v1.61)
-REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.21 v1.4)
+GOLANGCI_LINT_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.22 v1.63.4)
+REVIVE_VERSION ?= $(shell $(TOOLSDIR)/get_version.sh 1.22 v1.4)
 
 GOLANGCI_LINT_URL ?= github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT ?= $(GO) run $(GOLANGCI_LINT_URL)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module darvaza.org/acmefy
 
-go 1.21
+go 1.22
 
 require github.com/go-jose/go-jose/v4 v4.0.4

--- a/pkg/respond/go.mod
+++ b/pkg/respond/go.mod
@@ -1,6 +1,6 @@
 module darvaza.org/acmefy/pkg/respond
 
-go 1.21
+go 1.22
 
 require (
 	darvaza.org/acmefy v0.4.6

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "1.21"
+      "allowedVersions": "1.22"
     },
     {
       "groupName": "Darvaza Projects",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Updated project to use Go version 1.22
  - Updated linting and development tools to support Go 1.22
  - Configured GitHub Actions workflow to test against Go 1.22 and 1.23
  - Updated Renovate configuration to recognize Go 1.22

<!-- end of auto-generated comment: release notes by coderabbit.ai -->